### PR TITLE
switched the BlogDetailsView to go right to post

### DIFF
--- a/Hanselman.Shared/Views/BlogDetailsView.cs
+++ b/Hanselman.Shared/Views/BlogDetailsView.cs
@@ -8,11 +8,7 @@ namespace Hanselman.Shared
 		public BlogDetailsView (FeedItem item)
 		{
 			BindingContext = item;
-			var webView = new WebView ();
-			webView.Source = new HtmlWebViewSource {
-				Html = item.Description
-			};
-			Content = webView;
+		    Content = new WebView { Source = item.Link };
 		}
 	}
 }


### PR DESCRIPTION
switched the BlogDetailsView to use the FeedItem Link vs Description to navigate to full blog post