### PR TITLE
Solution for Issue 57: Clicking Pause and then Play was not working. …

### DIFF
--- a/Hanselman.Portable/Views/Channel9VideoPlaybackPage.xaml.cs
+++ b/Hanselman.Portable/Views/Channel9VideoPlaybackPage.xaml.cs
@@ -31,7 +31,7 @@ namespace Hanselman.Portable.Views
 
         private async void OnPlayClicked(object sender, EventArgs e)
         {
-            await CrossMediaManager.Current.VideoPlayer.Play();
+            await CrossMediaManager.Current.Play();
             pause.IsEnabled = true;
             stop.IsEnabled = true;
         }


### PR DESCRIPTION
…Play did nothing. Now, for Android it resumes at a place before but near where it Paused. In UWP it restarts at the beginning. In iOS it works as expected.