### PR TITLE
Fixing Null Value

### DIFF
--- a/Hanselman.Portable/ViewModels/PodcastViewModel.cs
+++ b/Hanselman.Portable/ViewModels/PodcastViewModel.cs
@@ -106,12 +106,12 @@ namespace Hanselman.Portable.ViewModels
                         where enclosure != null
                         select new FeedItem
                         {
-                            Title = (string)item.Element("title"),
-                            Description = (string)item.Element("description"),
-                            Link = (string)item.Element("link"),
-                            PublishDate = (string)item.Element("pubDate"),
-                            Category = (string)item.Element("category"),
-                            Mp3Url = (string)enclosure.Attribute("url"),
+                            Title = (string)item.Element("title") ?? "",
+                            Description = (string)item.Element("description") ?? "",
+                            Link = (string)item.Element("link") ?? "",
+                            PublishDate = (string)item.Element("pubDate") ?? "",
+                            Category = (string)item.Element("category") ?? "",
+                            Mp3Url = (string)enclosure.Attribute("url") ?? "",
                             Image = image,
                             Id = id++
                         }).ToList();


### PR DESCRIPTION
When there is an empty property, it wasn't handle properly. The app stopped when browsing Hanselminutes, which has 668 records. I was not sure which particular record has empty value. So I fix it with null coalescing operator and assign empty string if there is null.