### PR TITLE
Better localized date format support

### DIFF
--- a/src/Hanselman/Helpers/Utils.cs
+++ b/src/Hanselman/Helpers/Utils.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using System.Text.RegularExpressions;
 using Humanizer;
 
 // avagadavagam cheered 1000 March 8, 2019
@@ -16,11 +17,18 @@ namespace Hanselman.Helpers
                 return date.Humanize();
             else
             {
-                var time = date.ToShortTimeString();
-                var monthDay = CultureInfo.CurrentCulture.DateTimeFormat.MonthDayPattern.Replace("MMMM", "MMM");
-                // Twitter: 10:56 AM · Mar 7, 2019
-                return $"{time} · {date.ToString($"{monthDay}, yyyy")}";
+                return date.ToHumanizeDate();
             }
+        }
+
+        public static string ToHumanizeDate(this DateTime date, CultureInfo culture = null)
+        {
+            if (culture == null)
+                culture = CultureInfo.CurrentCulture;
+
+            var regex = new Regex("dddd[,]{0,1}");
+            var shortDatePattern = regex.Replace(culture.DateTimeFormat.LongDatePattern.Replace("MMMM", "MMM"), "").Trim();
+            return date.ToString($"{culture.DateTimeFormat.ShortTimePattern} · {shortDatePattern}", culture);
         }
     }
 }


### PR DESCRIPTION
Fix #101 

Examples:
- fr-FR : 12:59 - 9 mars 2019
- en-US : 12:59 PM - Mar 9, 2019
- en-GB : 12:59 - 09 Mar 2019
- de-DE : 12:59 - 9. Mrz 2019
- ja-JP : 12:59 - 2019年3月9日