### PR TITLE
You gotta POP tha MODAL

### DIFF
--- a/src/Hanselman/Views/Podcasts/PodcastEpisodePage.xaml.cs
+++ b/src/Hanselman/Views/Podcasts/PodcastEpisodePage.xaml.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Hanselman.Models;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
@@ -24,7 +20,7 @@ namespace Hanselman.Views.Podcasts
 
         private async void ButtonClose_Clicked(object sender, EventArgs e)
         {
-            await Navigation.PopAsync();
+            await Navigation.PopModalAsync();
         }
     }
 }


### PR DESCRIPTION
Small fix allowing to close the Podcast episode detail page, it was opened as Modal, so we need to pop it as modal too...