### PR TITLE
Fixed podcast icon labels getting cut using proportional width values

### DIFF
--- a/src/Hanselman/Views/Podcasts/PodcastEpisodePage.xaml
+++ b/src/Hanselman/Views/Podcasts/PodcastEpisodePage.xaml
@@ -99,11 +99,11 @@
                     ColumnSpacing="0"
                     RowSpacing="5">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="125" />
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="24*" />
+                        <ColumnDefinition Width="24*" />
+                        <ColumnDefinition Width="35*" />
+                        <ColumnDefinition Width="24*" />
+                        <ColumnDefinition Width="24*" />
                     </Grid.ColumnDefinitions>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -137,7 +137,8 @@
                         Margin="0,-5,0,0"
                         FontSize="Micro"
                         HorizontalOptions="Center"
-                        Text="Download" />
+                        Text="Download"
+                        HorizontalTextAlignment="Center"/>
 
                     <ImageButton
                         Grid.Row="0"
@@ -160,7 +161,8 @@
                         Margin="0,-5,0,0"
                         FontSize="Micro"
                         HorizontalOptions="Center"
-                        Text="Up Next" />
+                        Text="Up Next"
+                        HorizontalTextAlignment="Center"/>
 
                     <ImageButton
                         Grid.Row="0"
@@ -183,7 +185,8 @@
                         Margin="0,-5,0,0"
                         FontSize="Micro"
                         HorizontalOptions="Center"
-                        Text="Mark Played" />
+                        Text="Mark Played"
+                        HorizontalTextAlignment="Center"/>
 
                     <ImageButton
                         Grid.Row="0"
@@ -205,7 +208,8 @@
                         Margin="0,-5,0,0"
                         FontSize="Micro"
                         HorizontalOptions="Center"
-                        Text="Archive" />
+                        Text="Archive"
+                        HorizontalTextAlignment="Center"/>
 
                     <BoxView
                         Grid.Row="2"


### PR DESCRIPTION
This is a fix for issue #116 

The previous star grid column sizing was not distributing the space between the podcast icons evenly.

I have used Proportional grid column sizing for podcast icons, ie 24* for Podcast Icons  as its dimensions of the `IconDownload`, `IconUpNext`, `IconMarkPlayed`, `IconArchived` itself and 35* for 3rd column which is the dimension of the `IconPlay`.

![Screenshot_Hanselman_20190518-132243](https://user-images.githubusercontent.com/14297705/58259680-a1842500-7d92-11e9-82c4-ae39bff35ded.png)
