### PR TITLE
Removed button margin for iOS and adjusted padding of buttons stackla…

### DIFF
--- a/src/Hanselman/Views/Blog/BlogCollectionPage.xaml
+++ b/src/Hanselman/Views/Blog/BlogCollectionPage.xaml
@@ -93,7 +93,7 @@
                                     </StackLayout>
                                     <StackLayout
                                         Grid.Row="2"
-                                        Padding="0,4,8,0"
+                                        Padding="{OnPlatform Android='0,4,8,0', iOS='16,4'}"
                                         HorizontalOptions="FillAndExpand"
                                         Orientation="Horizontal"
                                         Spacing="8">
@@ -101,7 +101,7 @@
                                             BackgroundColor="Transparent"
                                             BorderColor="Transparent"
                                             BorderWidth="0"
-                                            Margin="-8,0,0,0"
+                                            Margin="{OnPlatform Android='-8,0,0,0'}"
                                             Padding="0"
                                             HorizontalOptions="Start"
                                             VerticalOptions="End"
@@ -119,7 +119,7 @@
                                                 Visual="Default"
                                                 Padding="0"
                                                 FontSize="24"
-                                                Margin="0,0,-20,0"/>
+                                                Margin="{OnPlatform Android='0,0,-20,0'}"/>
                                     </StackLayout>
                                 </Grid>
                             </Frame>


### PR DESCRIPTION
This is a fix for issue #118 

On iOS devices, the Read and Share buttons text was getting cut off due to the negative margin being applied to them. Used the `OnPlatform` markup extension to apply this margin only on android.

Also adjusted the padding of the `StackLayout` holding these buttons to align them with the Caption.

![screenshot 66](https://user-images.githubusercontent.com/14297705/58261049-39830e00-7d95-11e9-9739-f2a386c05525.png)
