### PR TITLE
Added `x:DataType` to views to use compiled bindings

### DIFF
--- a/src/Hanselman/Views/About/AboutPage.xaml
+++ b/src/Hanselman/Views/About/AboutPage.xaml
@@ -4,8 +4,10 @@
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:viewmodels="clr-namespace:Hanselman.ViewModels"
+    xmlns:models="clr-namespace:Hanselman.Models;assembly=Hanselman"
     Title="Scott Hanselman"
-    BackgroundColor="{StaticResource WindowBackgroundColor}">
+    BackgroundColor="{StaticResource WindowBackgroundColor}"
+    x:DataType="viewmodels:AboutViewModel">
     <ContentPage.BindingContext>
         <viewmodels:AboutViewModel />
     </ContentPage.BindingContext>
@@ -38,7 +40,7 @@
                 Orientation="Horizontal"
                 Spacing="5">
                 <BindableLayout.ItemTemplate>
-                    <DataTemplate>
+                    <DataTemplate x:DataType="models:SocialItem">
                         <Button
                             Command="{Binding OpenUrlCommand}"
                             Style="{StaticResource MaterialButton}"

--- a/src/Hanselman/Views/Blog/BlogCollectionPage.xaml
+++ b/src/Hanselman/Views/Blog/BlogCollectionPage.xaml
@@ -6,7 +6,8 @@
     xmlns:android="clr-namespace:Xamarin.Forms.PlatformConfiguration.AndroidSpecific;assembly=Xamarin.Forms.Core"
     xmlns:d="http://xamarin.com/schemas/2014/forms/design"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:models="clr-namespace:Hanselman.Models;assembly=Hanselman.Shared"
+    xmlns:modelsShared="clr-namespace:Hanselman.Models;assembly=Hanselman.Shared"
+    xmlns:models="clr-namespace:Hanselman.Models;assembly=Hanselman"
     xmlns:pancake="clr-namespace:Xamarin.Forms.PancakeView;assembly=Xamarin.Forms.PancakeView"
     xmlns:pulltorefresh="clr-namespace:Refractored.XamForms.PullToRefresh;assembly=Refractored.XamForms.PullToRefresh"
     xmlns:viewmodels="clr-namespace:Hanselman.ViewModels"
@@ -16,7 +17,8 @@
     IsBusy="{Binding IsBusy}"
     NavigationPage.HasNavigationBar="{OnPlatform Android=false,
                                                  iOS=true}"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    x:DataType="viewmodels:BlogFeedViewModel">
     <d:ContentPage.BindingContext>
         <viewmodels:BlogFeedViewModel />
     </d:ContentPage.BindingContext>
@@ -36,18 +38,18 @@
                     <GridItemsLayout Orientation="Vertical" Span="{OnIdiom Phone=1, Tablet=3, Desktop=3, TV=5, Watch=1}" />
                 </CollectionView.ItemsLayout>
                 <d:CollectionView.ItemsSource>
-                    <x:Array Type="{x:Type models:FeedItem}">
-                        <models:FeedItem
+                    <x:Array Type="{x:Type modelsShared:FeedItem}">
+                        <modelsShared:FeedItem
                             Title="Awesome Title"
                             Caption="This is a caption of the blog article."
                             FirstImage="scott.png"
                             PublishDate="Today" />
-                        <models:FeedItem
+                        <modelsShared:FeedItem
                             Title="Awesome Title"
                             Caption="This is a caption of the blog article."
                             FirstImage="scott.png"
                             PublishDate="Today" />
-                        <models:FeedItem
+                        <modelsShared:FeedItem
                             Title="Awesome Title"
                             Caption="This is a caption of the blog article."
                             FirstImage="scott.png"
@@ -55,7 +57,7 @@
                     </x:Array>
                 </d:CollectionView.ItemsSource>
                 <CollectionView.ItemTemplate>
-                    <DataTemplate>
+                    <DataTemplate x:DataType="models:BlogFeedItem">
                         <Grid Padding="8">
                             <Frame
                                 Padding="0,0,0,0"

--- a/src/Hanselman/Views/Blog/BlogPage.xaml
+++ b/src/Hanselman/Views/Blog/BlogPage.xaml
@@ -4,10 +4,12 @@
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:controls="clr-namespace:ImageCircle.Forms.Plugin.Abstractions;assembly=ImageCircle.Forms.Plugin"
+    xmlns:viewmodels="clr-namespace:Hanselman.ViewModels"
+    xmlns:models="clr-namespace:Hanselman.Models"
     Title="{Binding Title}"
     Icon="{Binding Icon}"
-    IsBusy="{Binding IsBusy}">
-
+    IsBusy="{Binding IsBusy}"
+    x:DataType="viewmodels:BlogFeedViewModel">
     <AbsoluteLayout HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand">
         <ListView
             x:Name="listView"
@@ -22,7 +24,7 @@
             RowHeight="175"
             SelectedItem="{Binding SelectedFeedItem}">
             <ListView.ItemTemplate>
-                <DataTemplate>
+                <DataTemplate x:DataType="models:BlogFeedItem">
                     <ViewCell>
                         <Grid Padding="10">
                             <Grid.ColumnDefinitions>

--- a/src/Hanselman/Views/Podcasts/PodcastDetailsPage.xaml
+++ b/src/Hanselman/Views/Podcasts/PodcastDetailsPage.xaml
@@ -10,7 +10,8 @@
     xmlns:models="clr-namespace:Hanselman.Models;assembly=Hanselman.Shared"
     xmlns:viewmodels="clr-namespace:Hanselman.ViewModels"
     mc:Ignorable="d"
-    BackgroundColor="{StaticResource WindowBackgroundColor}">
+    BackgroundColor="{StaticResource WindowBackgroundColor}"
+    x:DataType="viewmodels:PodcastDetailsViewModel">
     <ContentPage.BindingContext>
         <viewmodels:PodcastDetailsViewModel />
     </ContentPage.BindingContext>
@@ -113,7 +114,7 @@
                     </pancake:PancakeView>
                 </ListView.Header>
                 <ListView.ItemTemplate>
-                    <DataTemplate>
+                    <DataTemplate x:DataType="models:PodcastEpisode">
                         <ViewCell>
                             <Grid Padding="10" ColumnSpacing="10">
                                 <Grid.ColumnDefinitions>

--- a/src/Hanselman/Views/Podcasts/PodcastDirectoryPage.xaml
+++ b/src/Hanselman/Views/Podcasts/PodcastDirectoryPage.xaml
@@ -7,9 +7,11 @@
     xmlns:effects="clr-namespace:Hanselman.Effects"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:viewmodels="clr-namespace:Hanselman.ViewModels"
+    xmlns:models="clr-namespace:Hanselman.Models;assembly=Hanselman.Shared"
     Title="Podcasts"
     BackgroundColor="{StaticResource WindowBackgroundColor}"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    x:DataType="viewmodels:PodcastDirectoryViewModel">
     <ContentPage.BindingContext>
         <viewmodels:PodcastDirectoryViewModel />
     </ContentPage.BindingContext>
@@ -25,7 +27,7 @@
                     JustifyContent="Start"
                     Wrap="Wrap">
                     <BindableLayout.ItemTemplate>
-                        <DataTemplate>
+                        <DataTemplate x:DataType="models:Podcast">
                             <StackLayout
                                 Margin="4,4,4,4"
                                 FlexLayout.AlignSelf="Start"

--- a/src/Hanselman/Views/Podcasts/PodcastPlaybackPage.xaml
+++ b/src/Hanselman/Views/Podcasts/PodcastPlaybackPage.xaml
@@ -2,7 +2,9 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Hanselman.Views.PodcastPlaybackPage"
-             Title ="{Binding Title}">
+             xmlns:models="clr-namespace:Hanselman.Models;assembly=Hanselman.Shared"
+             Title ="{Binding Title}"
+             x:DataType="models:FeedItem">
     <StackLayout Padding="10" Spacing="5">
         <Label Text="{Binding Title}" FontSize="Medium" x:Name="title" />
         <Label Text="{Binding PublishDate}" x:Name="date"/>

--- a/src/Hanselman/Views/Twitter/TweetCell.xaml
+++ b/src/Hanselman/Views/Twitter/TweetCell.xaml
@@ -5,7 +5,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:d="http://xamarin.com/schemas/2014/forms/design"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    xmlns:modelsShared="clr-namespace:Hanselman.Models;assembly=Hanselman.Shared"
+    mc:Ignorable="d"
+    x:DataType="modelsShared:Tweet">
     <Frame
         Margin="8,4"
         Padding="12"

--- a/src/Hanselman/Views/Twitter/TweetWithMediaCell.xaml
+++ b/src/Hanselman/Views/Twitter/TweetWithMediaCell.xaml
@@ -5,7 +5,9 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:d="http://xamarin.com/schemas/2014/forms/design"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+    xmlns:modelsShared="clr-namespace:Hanselman.Models;assembly=Hanselman.Shared"
+    mc:Ignorable="d"
+    x:DataType="modelsShared:Tweet">
     <Frame
         Margin="8,4"
         Padding="12"

--- a/src/Hanselman/Views/Twitter/TwitterPage.xaml
+++ b/src/Hanselman/Views/Twitter/TwitterPage.xaml
@@ -5,7 +5,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:d="http://xamarin.com/schemas/2014/forms/design"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:models="clr-namespace:Hanselman.Models;assembly=Hanselman.Shared"
+    xmlns:modelsShared="clr-namespace:Hanselman.Models;assembly=Hanselman.Shared"
+    xmlns:viewmodels="clr-namespace:Hanselman.ViewModels"
     xmlns:twitter="clr-namespace:Hanselman.Views.Twitter"
     Title="{Binding Title}"
     BackgroundColor="{StaticResource WindowBackgroundColor}"
@@ -13,7 +14,8 @@
     IsBusy="{Binding IsBusy}"
     NavigationPage.HasNavigationBar="{OnPlatform Android=false,
                                                  iOS=true}"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    x:DataType="viewmodels:TwitterViewModel">
     <ContentPage.Resources>
         <ResourceDictionary>
             <DataTemplate x:Key="TweetTemplate">
@@ -41,13 +43,13 @@
             RefreshCommand="{Binding RefreshCommand}"
             SeparatorColor="Transparent">
             <d:ListView.ItemsSource>
-                <x:Array Type="{x:Type models:Tweet}">
-                    <models:Tweet
+                <x:Array Type="{x:Type modelsShared:Tweet}">
+                    <modelsShared:Tweet
                         Image="scott.png"
                         MediaUrl="scott.png"
                         ScreenName="scotthanselman"
                         Text="Hello world this is a tweet, james is pretty awesome, and this app is amazing!!!!" />
-                    <models:Tweet
+                    <modelsShared:Tweet
                         Image="scott.png"
                         ScreenName="scotthanselman"
                         Text="Hello world this is a tweet, james is pretty awesome, and this app is amazing!!!!" />


### PR DESCRIPTION
# `x:DataType` for all the views <3

Hi @jamesmontemagno , I dont know if you remember me from [this stream](https://www.twitch.tv/videos/461649019?sr=a&t=5025s), but I wanted to contribute to your app.

In these changes I have added `x:DataType` to all of your views. This is so the project uses the [compiled bindings](https://docs.microsoft.com/en-us/xamarin/xamarin-forms/app-fundamentals/data-binding/compiled-bindings).

> "Compiled bindings are resolved more quickly than classic bindings, therefore improving data binding performance in Xamarin.Forms applications."


It also gives you compile time errors when you have a binding that does not match the binding context. This should be helpful for future development.

**Notes** 
- Collection-controls that uses the `DataTemplate` also has to specify which `x:DataType` it is using, and this normally has to be set on the `DataTemplate` element.
- Missing on `PodcastEpisodePage` because I did not understand where the `IsBusy` property belongs. It is not in the `PodcastEpisodeViewModel`, which is the binding context of the page.

**Off topic**
I also want to highlight [this ](https://github.com/xamarin/Xamarin.Forms/issues/6865)issue in the `Xamarin/Forms` github repository. It would be very interesting if the `x:DataType` could be further developed so we can get propper intellisense in the IDE when we are working with it. That would truly be amazing!
