### PR TITLE
Bump to glidex.forms 2.0.0.336

### DIFF
--- a/src/Android/Hanselman.Android.csproj
+++ b/src/Android/Hanselman.Android.csproj
@@ -184,7 +184,7 @@
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <ItemGroup>
     <PackageReference Include="glidex.forms">
-      <Version>1.0.4</Version>
+      <Version>2.0.0.336</Version>
     </PackageReference>
     <PackageReference Include="Humanizer">
       <Version>2.7.2</Version>

--- a/src/Android/MainActivity.cs
+++ b/src/Android/MainActivity.cs
@@ -36,7 +36,7 @@ namespace HanselmanAndroid
             PullToRefreshLayoutRenderer.Init();
             CrossMediaManager.Current.Init(this);
             ImageCircleRenderer.Init();
-            Android.Glide.Forms.Init();
+            Android.Glide.Forms.Init(this);
             LoadApplication(new App());
         }
 


### PR DESCRIPTION
I just pushed out an update for glidex 2.0.0:

https://github.com/jonathanpeppers/glidex/releases

This uses the official Xamarin.Android.Glide NuGet package now:

https://www.nuget.org/packages/Xamarin.Android.Glide/

This app was a good test subject. It seems like the images are still working great?